### PR TITLE
Hotfix non user address

### DIFF
--- a/contracts/context/SaplingContext.sol
+++ b/contracts/context/SaplingContext.sol
@@ -68,7 +68,7 @@ abstract contract SaplingContext is Pausable {
      */
     function transferGovernance(address _governance) external onlyGovernance {
         require(
-            _governance != address(0) && isNonUserAddress(_governance),
+            _governance != address(0) && !isNonUserAddress(_governance),
             "SaplingContext: invalid governance address"
         );
         address prevGovernance = governance;
@@ -84,7 +84,7 @@ abstract contract SaplingContext is Pausable {
      */
     function transferTreasury(address _treasury) external onlyGovernance {
         require(
-            _treasury != address(0) && isNonUserAddress(_treasury),
+            _treasury != address(0) && !isNonUserAddress(_treasury),
             "SaplingContext: invalid treasury wallet address"
         );
         address prevTreasury = treasury;
@@ -105,6 +105,6 @@ abstract contract SaplingContext is Pausable {
      * @param party Address to verify
      */
     function isNonUserAddress(address party) internal view virtual returns (bool) {
-        return party != governance && party != treasury;
+        return party == governance || party == treasury;
     }
 }

--- a/contracts/context/SaplingManagerContext.sol
+++ b/contracts/context/SaplingManagerContext.sol
@@ -47,8 +47,7 @@ abstract contract SaplingManagerContext is SaplingContext {
 
     /// A modifier to limit access only to non-management users
     modifier onlyUser() {
-        require(msg.sender != manager && msg.sender != governance && msg.sender != treasury,
-             "SaplingManagerContext: caller is not a user");
+        require(!isNonUserAddress(msg.sender), "SaplingManagerContext: caller is not a user");
         _;
     }
 

--- a/contracts/context/SaplingManagerContext.sol
+++ b/contracts/context/SaplingManagerContext.sol
@@ -85,7 +85,7 @@ abstract contract SaplingManagerContext is SaplingContext {
      */
     function transferManager(address _manager) external onlyGovernance {
         require(
-            _manager != address(0) && isNonUserAddress(_manager),
+            _manager != address(0) && !isNonUserAddress(_manager),
             "SaplingManagerContext: invalid manager address"
         );
         address prevManager = manager;
@@ -132,7 +132,7 @@ abstract contract SaplingManagerContext is SaplingContext {
      * @param party Address to verify
      */
     function isNonUserAddress(address party) internal view override returns (bool) {
-        return party != manager && super.isNonUserAddress(party);
+        return party == manager || super.isNonUserAddress(party);
     }
     /**
      * @notice Indicates whether or not the contract can be closed in it's current state.

--- a/contracts/context/SaplingPoolContext.sol
+++ b/contracts/context/SaplingPoolContext.sol
@@ -569,8 +569,7 @@ abstract contract SaplingPoolContext is ILender, SaplingManagerContext, SaplingM
      *      certain actions when the manager is inactive.
      */
     function authorizedOnInactiveManager(address caller) internal view override returns (bool) {
-        return caller == governance || caller == treasury
-            || sharesToTokens(IERC20(poolToken).balanceOf(caller)) >= ONE_TOKEN;
+        return isNonUserAddress(caller) || sharesToTokens(IERC20(poolToken).balanceOf(caller)) >= ONE_TOKEN;
     }
 
     /**


### PR DESCRIPTION
Fixed the isNonUser() method to match the logic to it's name, and used it in two places where the address comparisons were one at a time.