### PR TITLE
Failed Pool Entry Prevention

### DIFF
--- a/contracts/SaplingLendingPool.sol
+++ b/contracts/SaplingLendingPool.sol
@@ -279,7 +279,7 @@ contract SaplingLendingPool is ILendingPool, SaplingPoolContext {
         uint256 lenderLoss = 0;
 
         if (totalLoss > 0) {
-            uint256 remainingLostShares = fundsToShares(totalLoss);
+            uint256 remainingLostShares = fundsToSharesBase(totalLoss, true);
 
             if (balances.stakedShares > 0) {
                 uint256 stakedShareLoss = MathUpgradeable.min(remainingLostShares, balances.stakedShares);

--- a/test/25.SaplingPoolContext.js
+++ b/test/25.SaplingPoolContext.js
@@ -604,7 +604,7 @@ describe('Sapling Pool Context (via SaplingLendingPool)', function () {
                 expect(limit).to.equal(stakeAmount.mul(oneHundredPercent / targetStakePercent));
             });
 
-            it('Staker can stake on a failed pool and have a correct pool balance', async function () {
+            it('Staker cannot stake on a failed pool', async function () {
                 await saplingPoolContext.connect(staker).stake(stakeAmount);
 
                 let depositAmount = BigNumber.from(10000).mul(TOKEN_MULTIPLIER);
@@ -652,8 +652,8 @@ describe('Sapling Pool Context (via SaplingLendingPool)', function () {
 
                 await liquidityToken.connect(deployer).mint(staker.address, depositAmount);
                 await liquidityToken.connect(staker).approve(saplingPoolContext.address, stakeAmount);
-                await saplingPoolContext.connect(staker).stake(stakeAmount);
-                expect(await saplingPoolContext.balanceStaked()).to.equal(stakeAmount.sub(1));
+                await expect(saplingPoolContext.connect(staker).stake(stakeAmount))
+                    .to.be.revertedWith('SaplingPoolContext: share price too low');
             });
 
             describe('Rejection scenarios', function () {


### PR DESCRIPTION
Prevents entry to pool when the share price is 95% down from launch.

As a side effect, pool also rejects any transactions using fundsToShares conversion when the pool funds is exactly zero. 

However such rejection is ok, as withdraw on zero pool funds would result in total loss of shares from a position. 

Reference: Fix-review WP-I5